### PR TITLE
Misc fixes: P+ footstool button and Ult joybus mode select

### DIFF
--- a/src/dac_algorithms/project_plus_F1.cpp
+++ b/src/dac_algorithms/project_plus_F1.cpp
@@ -151,7 +151,7 @@ GCReport getGCReport(GpioToButtonSets::F1::ButtonSet buttonSet) {
     gcReport.dUp = gcReport.dUp || bs.ms;
 
     /* Triggers */
-    gcReport.analogL = bs.l ? 140 : bs.ms ? 94 : bs.ls ? 49 : 0;
+    gcReport.analogL = bs.l ? 140 : bs.ls ? 49 : 0;
     gcReport.analogR = bs.r ? 140 : 0;
 
     /* Buttons */

--- a/src/dac_algorithms/project_plus_F1.cpp
+++ b/src/dac_algorithms/project_plus_F1.cpp
@@ -148,6 +148,7 @@ GCReport getGCReport(GpioToButtonSets::F1::ButtonSet buttonSet) {
         gcReport.dUp = bs.cUp;
         gcReport.dRight = bs.cRight;
     }
+    gcReport.dUp = gcReport.dUp || bs.ms;
 
     /* Triggers */
     gcReport.analogL = bs.l ? 140 : bs.ms ? 94 : bs.ls ? 49 : 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,12 @@ int main() {
                 return DACAlgorithms::ProjectPlusF1::getGCReport(GpioToButtonSets::F1::defaultConversion());
             });
         }
+
+        if (!gpio_get(6)) { // 9-GP6 : F1 / ultimate
+            CommunicationProtocols::Joybus::enterMode(gcDataPin, [](){
+                return DACAlgorithms::UltimateF1::getGCReport(GpioToButtonSets::F1::defaultConversion());
+            });
+        }
         
         // Else: F1 / Melee
         CommunicationProtocols::Joybus::enterMode(gcDataPin, [](){ return DACAlgorithms::MeleeF1::getGCReport(GpioToButtonSets::F1::defaultConversion()); });


### PR DESCRIPTION
Added MS as dUp to match Haystack's logic, just tested and seems to work fine.
Also quickly added the Ult joybus mode switch while I was at it, can't really test it properly as I don't play ultimate or have a switch to properly test it but on the P+ CSS it seems to have ult logic. Put it on MX/GP6 to be the same as adapter mode.