### PR TITLE
Adjusted README to mention non-usb Ultimate mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you want to prevent this electrically, use Schottky diodes, or power VSYS wit
 
 As of this release, 8 modes are built-in.
 
-- Not plugged into USB => Console mode (Melee F1 DAC algorithm + Joybus), unless you press GP2 or GP7 (by default Right and MY), in which case you enter P+ mode. If you're not plugged into USB, you enter this mode.
+- Not plugged into USB => Console mode (Melee F1 DAC algorithm + Joybus), unless you also press GP2 or GP7 (by default Right and MY), in which case you enter P+ mode, or GP6 (by default MX), in which case you enter Ultimate mode. If you're not plugged into USB, you enter this mode.
 
 - Plugged into USB, nothing pressed => Melee GCC to USB adapter mode (Melee F1 DAC algorithm + Adapter USB configuration).
 
@@ -150,6 +150,7 @@ If it doesn't appear to work, double check all 20 of your buttons work. Note tha
 - Plug in your Raspberry Pico to your computer by holding pin GP26 (the CRight button in the advised pinout) via USB (i.e BOOTSEL mode), or while holding the "BOOTSEL" white button on the board.
 
 - The board should appear as an external drive. Put the .uf2 in there. The board should disconnect and be ready for use.
+  - If you reconnect the board in BOOTSEL mode, you may not see the .uf2 file anymore. This is normal, expected behavior.
 
 ### How to wire the board:
 
@@ -174,6 +175,8 @@ Note that all "button" pin mappings can be modified later on using the runtime r
 Console mode/B/R don't work -> Did you connect pin 33 to ground ?
 
 Nothing but B/R works -> Did you connect pin 38 to ground ?
+
+Only half/some of my buttons do anything -> Double-check your common ground between all of your buttons.
 
 ### Closing notes
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you want to prevent this electrically, use Schottky diodes, or power VSYS wit
 
 As of this release, 8 modes are built-in.
 
-- Not plugged into USB => Console mode (Melee F1 DAC algorithm + Joybus), unless you also press GP2 or GP7 (by default Right and MY), in which case you enter P+ mode, or GP6 (by default MX), in which case you enter Ultimate mode. If you're not plugged into USB, you enter this mode.
+- Not plugged into USB => Console mode (Melee F1 DAC algorithm + Joybus), unless you press GP2 or GP7 (by default Right and MY), in which case you enter P+ mode, or GP6 (by default MX), in which case you enter Ultimate mode. If you're not plugged into USB, you enter this mode.
 
 - Plugged into USB, nothing pressed => Melee GCC to USB adapter mode (Melee F1 DAC algorithm + Adapter USB configuration).
 
@@ -150,7 +150,8 @@ If it doesn't appear to work, double check all 20 of your buttons work. Note tha
 - Plug in your Raspberry Pico to your computer by holding pin GP26 (the CRight button in the advised pinout) via USB (i.e BOOTSEL mode), or while holding the "BOOTSEL" white button on the board.
 
 - The board should appear as an external drive. Put the .uf2 in there. The board should disconnect and be ready for use.
-  - If you reconnect the board in BOOTSEL mode, you may not see the .uf2 file anymore. This is normal, expected behavior.
+
+If you reconnect the board in BOOTSEL mode, you won't see the .uf2 file anymore. This is normal, expected behavior.
 
 ### How to wire the board:
 


### PR DESCRIPTION
On first read, I thought the Ultimate DAC might be exclusive to USB mode, which was changed with https://github.com/JulienBernard3383279/pico-rectangle/pull/6. I figure it's worth adjusting/making things a bit more explicit.

I also added a troubleshooting note about common grounds since I saw it come up in Crane's discord a couple of times. And a note about the .u2f file disappearing, since this caught me off-guard as someone new to working with a pi pico.