### PR TITLE
Add GitHub Action to build the firmware with cmake.

### DIFF
--- a/.github/cmake-firmware.yml
+++ b/.github/cmake-firmware.yml
@@ -1,0 +1,42 @@
+name: CMake
+
+on: [push]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+      # os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
+
+    steps:
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE
+

--- a/.github/cmake-firmware.yml
+++ b/.github/cmake-firmware.yml
@@ -4,7 +4,8 @@ on: [push]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  # BUILD_TYPE: Release
+  PICO_SDK_DIR: ./pico-sdk
 
 jobs:
   build:
@@ -19,24 +20,45 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
+    - uses: actions/checkout@v2
+      name: Checkout repository
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - uses: actions/checkout@master
+      name: Checkout pico sdk
+      with:
+        repository: raspberrypi/pico-sdk
+        path: ${{ env.PICO_SDK_DIR }}
+    # From https://docs.google.com/document/d/1-Lx3X7zIwRscp6N76_usy5fdwulo6-chML3Xjfz3zaY/
+    - name: Set pico-sdk path in CMakeLists.
+      run: sed 's/#set(PICO_SDK_PATH "..\/..\/pico-sdk"/set(PICO_SDK_PATH ".\/pico-sdk"/' -i CMakeLists.txt
+
+    # From https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf
+    - name: Update apt and install cmake
+      - run: sudo apt update -y
+      - run: sudo apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
+
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
       # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{github.workspace}}/build
 
-    - name: Configure CMake
+    # - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
-      shell: bash
-      working-directory: ${{github.workspace}}/build
+      # shell: bash
+      # working-directory: ${{github.workspace}}/build
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
+      # run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
 
     - name: Build
       working-directory: ${{github.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE
+      # run: cmake --build . --config $BUILD_TYPE
+      # From Step 3: https://docs.google.com/document/d/1-Lx3X7zIwRscp6N76_usy5fdwulo6-chML3Xjfz3zaY/edit
+      run: cmake ..
+      run: make
 

--- a/.github/cmake-firmware.yml
+++ b/.github/cmake-firmware.yml
@@ -1,6 +1,9 @@
 name: CMake
 
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, edited, closed, reopened]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -62,3 +65,6 @@ jobs:
       run: cmake ..
       run: make
 
+    - name: List things
+      working-directory: ${{github.workspace}}/build
+      run: ls -R

--- a/.github/workflows/cmake-firmware.yml
+++ b/.github/workflows/cmake-firmware.yml
@@ -37,8 +37,9 @@ jobs:
       run: sed 's/#set(PICO_SDK_PATH "..\/..\/pico-sdk"/set(PICO_SDK_PATH ".\/pico-sdk"/' -i CMakeLists.txt
     # From https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf
     - name: Update apt and install cmake
-      run: sudo apt update -y
-      run: sudo apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
+      run: |
+        sudo apt update -y
+        sudo apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
@@ -61,8 +62,9 @@ jobs:
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       # run: cmake --build . --config $BUILD_TYPE
       # From Step 3: https://docs.google.com/document/d/1-Lx3X7zIwRscp6N76_usy5fdwulo6-chML3Xjfz3zaY/edit
-      run: cmake ..
-      run: make
+      run: |
+        cmake .. 
+        make
 
     - name: List things
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake-firmware.yml
+++ b/.github/workflows/cmake-firmware.yml
@@ -7,14 +7,16 @@ on:
 
 env:
   PICO_SDK_DIR: ./pico-sdk
+  FIRMWARE_ARTIFACT_PATH: ./build/
 
 jobs:
-  build:
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  build-firmware:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+      # Can support other os', such as windows-latest and macos-latest.
       # os: [ubuntu-latest, windows-latest]
+      # But there's syntactic toolchain differences, especially with gnu coreutils, so we'll leave that for later.
         os: [ubuntu-latest]
 
     steps:
@@ -41,8 +43,6 @@ jobs:
         sudo apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
 
     - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{github.workspace}}/build
 
     - name: CMake and Make the Firmware
@@ -58,3 +58,13 @@ jobs:
     - name: List things
       working-directory: ${{github.workspace}}/build
       run: ls -laR
+
+    # Note: Artifacts are uploaded as a ZIP, which currently cannot be customized. https://github.com/actions/upload-artifact#zipped-artifact-downloads
+    # This generally reduces the uf2 file size between 30-60%.
+    # TODO: Tweak artifact retention limit. 90 days is the default and the max, but users can always push an empty commit to their PR to build and download the latest uf2!
+    - name: Upload firmware artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: pico_rectangle_${{ github.sha }}.uf2
+        path: ${{github.workspace}}/build/pico_rectangle.uf2
+        if-no-files-found: error

--- a/.github/workflows/cmake-firmware.yml
+++ b/.github/workflows/cmake-firmware.yml
@@ -9,6 +9,10 @@ env:
   PICO_SDK_DIR: ./pico-sdk
   FIRMWARE_ARTIFACT_PATH: ./build/
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id || github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   build-firmware:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cmake-firmware.yml
+++ b/.github/workflows/cmake-firmware.yml
@@ -1,4 +1,4 @@
-name: CMake
+name: CMake Firmware
 
 on:
   push:
@@ -6,15 +6,10 @@ on:
     types: [opened, edited, closed, reopened]
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  # BUILD_TYPE: Release
   PICO_SDK_DIR: ./pico-sdk
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ${{ matrix.os }}
     strategy:
@@ -33,8 +28,12 @@ jobs:
         repository: raspberrypi/pico-sdk
         path: ${{ env.PICO_SDK_DIR }}
     # From https://docs.google.com/document/d/1-Lx3X7zIwRscp6N76_usy5fdwulo6-chML3Xjfz3zaY/
+    # CMake assumes the sdk path is relative to the `build` directory.
     - name: Set pico-sdk path in CMakeLists.
-      run: sed 's/#set(PICO_SDK_PATH "..\/..\/pico-sdk"/set(PICO_SDK_PATH ".\/pico-sdk"/' -i CMakeLists.txt
+      run: |
+        sed 's/#set(PICO_SDK_PATH "..\/..\/pico-sdk"/set(PICO_SDK_PATH "..\/pico-sdk"/' -i CMakeLists.txt
+        cat CMakeLists.txt
+
     # From https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf
     - name: Update apt and install cmake
       run: |
@@ -46,17 +45,7 @@ jobs:
       # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{github.workspace}}/build
 
-    # - name: Configure CMake
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      # shell: bash
-      # working-directory: ${{github.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source 
-      # and build directories, but this is only available with CMake 3.13 and higher.  
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      # run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
-
-    - name: Build
+    - name: CMake and Make the Firmware
       working-directory: ${{github.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
@@ -68,4 +57,4 @@ jobs:
 
     - name: List things
       working-directory: ${{github.workspace}}/build
-      run: ls -R
+      run: ls -laR

--- a/.github/workflows/cmake-firmware.yml
+++ b/.github/workflows/cmake-firmware.yml
@@ -23,6 +23,9 @@ jobs:
       # But there's syntactic toolchain differences, especially with gnu coreutils, so we'll leave that for later.
         os: [ubuntu-latest]
 
+    # TODO: The pico-sdk checkout can probably be cached, as well as the apt update (probably changes more frequently) and cmake install (less frequent changes).
+    # Doing this could save on a lot of the Action setup time, at the cost of some of the Cache Size (so less artifacts could be stored).
+    # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
     steps:
     - uses: actions/checkout@v2
       name: Checkout repository

--- a/.github/workflows/cmake-firmware.yml
+++ b/.github/workflows/cmake-firmware.yml
@@ -35,11 +35,10 @@ jobs:
     # From https://docs.google.com/document/d/1-Lx3X7zIwRscp6N76_usy5fdwulo6-chML3Xjfz3zaY/
     - name: Set pico-sdk path in CMakeLists.
       run: sed 's/#set(PICO_SDK_PATH "..\/..\/pico-sdk"/set(PICO_SDK_PATH ".\/pico-sdk"/' -i CMakeLists.txt
-
     # From https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf
     - name: Update apt and install cmake
-      - run: sudo apt update -y
-      - run: sudo apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
+      run: sudo apt update -y
+      run: sudo apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/.github/workflows/cmake-firmware.yml
+++ b/.github/workflows/cmake-firmware.yml
@@ -52,15 +52,17 @@ jobs:
     - name: Create Build Environment
       run: cmake -E make_directory ${{github.workspace}}/build
 
-    - name: CMake and Make the Firmware
+    - name: CMake the Firmware
       working-directory: ${{github.workspace}}/build
       shell: bash
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
-      # run: cmake --build . --config $BUILD_TYPE
       # From Step 3: https://docs.google.com/document/d/1-Lx3X7zIwRscp6N76_usy5fdwulo6-chML3Xjfz3zaY/edit
-      run: |
-        cmake .. 
-        make
+      run: cmake ..
+
+    - name: Final `make`
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      # From Step 3: https://docs.google.com/document/d/1-Lx3X7zIwRscp6N76_usy5fdwulo6-chML3Xjfz3zaY/edit
+      run: make
 
     - name: List things
       working-directory: ${{github.workspace}}/build


### PR DESCRIPTION
### tl;dr

I added a lot of info and breakdown for posterity and interested folks.

But in short, this PR adds a GitHub Action, which is just GitHub running a server that runs the build and uploads the finished `.uf2` firmware file for download. For free.

I try to clarify more below, but it's verbose - feel free to ask questions in comments without reading below, or bug me on Discord. User [`SuperFightingHobo#9516`](https://discordapp.com/users/SuperFightingHobo#9516).

Due to security reasons, I think GitHub won't run the Action itself on this initial PR. But you can see it in action from the links in the Description section below.

---

### Description / etc.

This PR adds a GitHub Action that tries to build the `.uf2` firmware file on each PR as well as each branch Push event.

If the build succeeds, it publishes the resultant .uf2 file as an Artifact.

I think this should make it a lot easier for users to build and test their own firmware changes - it shifts the difficulty from both git and github interaction + running cmake and make locally, to only interacting with GitHub. The latter is easier to write tutorials around and troubleshoot, IMO.

Example source PR: [ajshepley/pico-rectangle/pull/1](https://github.com/ajshepley/pico-rectangle/pull/1)
Example Action/workflow result: https://github.com/ajshepley/pico-rectangle/actions/runs/2142682537
Example compiled Artifact (uf2 file): https://github.com/ajshepley/pico-rectangle/suites/6061751099/artifacts/209276707

---

### GitHub Limits

GitHub seems to have these restrictions for Artifacts, Caches and Packages/releases for public repos:
- 90 day Artifact retention
- 10GB per-month traffic (downloads/uploads for artifacts?)
- 500MB(?) stored file size for artifacts.
- 2000 CI minutes per month for Actions. (Note that Windows builds have a 2x times multiplier, and MacOS has a 10x time multiplier).

The average artifact size is <40KB and takes <2 minutes to build, so I don't think these are concerned. And if it ends up being a problem, Step Caching can be explored to possibly vastly speed up the Action at the expense of the stored file size limit.

But users can just fork the repo and run the Action on their fork, sidestepping the limits entirely.

In any case, I don't think we'd need to be concerned at all. But I'm totally willing to help out if it becomes a problem or a concern.

---

### Testing

I downloaded the uf2 from one of the artifacts and threw it on my Pico.

Uploading over bootsel USB seemed to work fine.

I tested melee (unclepunch in dolphin, plugged into a usb3 port). Seemed to work fine as far as I could tell, but I'm not good at melee so I wouldn't see any subtle issues.

I tested Ultimate over direct USB (held MX for ultimate mode) on a Switch dock, and it seemed to work fine.

I tested Ultimate via a gamecube adapter, and it seemed to work fine, as far as I could tell.

There might be an avenue for an automated test suite here (e.g. an interactive app, asking you to press each button or button combo in series) but that's an idea for Future Helpful Contributor™️.

I recorded most of the above with `moverlay` and nintendospy active (respectively), so I can add those clips if desired. But it'd take a few minutes to lower the filesize, trim, convert and upload them, so I'm avoiding that unless anyone thinks it'd be helpful or useful.

---

### Action Failures

When an Action succeeds or fails, it adds a Green checkmark or a red X to the commit that it ran against.

Under default repo settings, this shouldn't affect anything. But there are various configurations that can be made to prevent PRs from being merged when these statuses are Failures (or, prevent PRs from being merged without a Green action status).

Part of the idea behind this is to help prevent PRs from being merged if they break the build. However, I don't have 100% confidence that the Action reflects a truly correct build, 100% of the time. As such, I don't think that it makes sense (yet) to enable the "prevent merges until the Action succeeds" settings. But it may be a good idea after a few months after merge, once the Action's stability and accuracy is confirmed (or not).

And so, if the Action starts failing (say, due to pico-sdk changes) it may put red X's on PRs and commits. At that point we'd want to disable the Action, or address the issue, or add a readme (or PR template line) to ignore the issue.

---

### Notes and caveats

<details>
<summary>Some extra notes (sorry for the verbosity, I think it'll be useful for posterity). Click to expand...🖱️ </summary>

- I separated the individual steps into what I think are logical pieces. For example, I separate the final `cmake` and `make` calls, which gives them separate sections in the Action logging section. But this is just a first-stab at the idea, I can combine or separate things if there's any good ideas about it.
- I squashed some stuff, but kept some separate seminal commits. The initial commit came from some common cmake GitHub Actions I found on github search. I'm not sure if there's licensing implications. By the last commit, basically none of the code is shared with that initial commit - so if there's any concerns, I can rework the branch to remove the initial commit.
- I left some useful TODOs in the action itself. Some projects like TODOs, some don't. I can remove them if they're annoying.
- The build is linux-based. I tried windows but it failed on my call to `sed`, probably due to a tooling difference (gnu coreutils use different flags than bsd coreutils, etc.). If we want Windows builds this would need to be adjusted. Another option would be specifying a default pico-sdk path in the existing CMakeLists.txt, etc. That'd disrupt anyone's local workspace though. That can be considered later, in any case. I wouldn't be surprised if the `make` or `cmake` calls also end up failing on Windows in a hard-to-resolve way.
- The workflow calls `apt update` and `apt install`, which can be time intensive. GitHub's `ubuntu-latest` is sometimes a bit out of date. We could try caching these steps but I'm unfamiliar with how that works. It's an optimization that can be made in the future, so I left a TODO.
- This workflow checks out the latest master of the pico-sdk repository. This means that it could be potentially unstable if `raspberrypi` make breaking changes. I could pin to a specific SHA, ref or branch, but maybe this setup would be a useful way of discovering a breakage like that. I don't know how often they make such changes anyways; their own documentation says to pull master.
- GitHub Actions may or may not run on the PR that is creating them for a repo. I think GitHub doesn't execute them for non-maintainers as a security precaution. Once merged, this should execute fine for any new PRs (but I don't know how PRs that edit the action will play out). 
- This didn't seem to need [$GITHUB_TOKEN](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) when running on my fork. It may only be needed for actions that modify the repo? In any case, if anyone sees access/permission problems, then adding this variable might be the solution. Alternatively, creating a Personal Access Token (PAT) and adding it to the secrets for the repository (in Settings) would also be a solution. Hopefully it "just works" after merge.
- General GitHub Action Optimizations: I haven't written many Actions or workflows, so there may be better or more optimal ways of doing this. This just happened to... work, so I figured it was worth submitting as-is. I'll be happy to help review any PRs that modify the action or improve or replace it, it's a good way for me to learn 😄.
- Artifacts are uploaded/downloaded as ZIP files, despite what the UI says. The `uf2` is inside, and the filesize is 1/3 which is nice. It's just a bit tedious to unzip when testing. I don't think I can do anything about this, unfortunately.
- The upload step is configured to fail if the artifact is not detected, but I didn't test this much.
- The entire Action is configured to Cancel if a new commit is Action is detected for the same commit ref (SHA), or the same Job id, or the same event number (PR). I did not test this significantly. This is a bit of premature optimization. If it causes issues I can remove it.
- It may be a good idea to add both a Pull Request template and a README section that mentions the Action, and where to find the Artifacts for your PR or branch. Or incorporate it into a "how to build your own firmware" tutorial later.
- On Crane's Discord, user [Sticks mentioned](https://discord.com/channels/557665530199146497/557665530677559307/962552731988549634) that their filesize was 183KB, consistently, after each build, whereas the GitHub Action produces a ~93.5KB file. This is a **concerning difference**, but the latter is in line with the firmware releases, so it's possible that it's a platform, library, build or build config difference (extra included symbols, e.g. debug or dev symbols?). I don't know enough about hardware/pico dev to look into this further. Might be a good reason to get the Windows and MacOS matrix builds working. In any case, I think it's not a blocker here, but a good reason to add a warning of "Download/use at your own risk". Assuming the ~180KB uf2 filesize is consistent for all other builders.

</details>

I haven't built C/pp projects with github actions before, so I'm a bit surprised that it just kinda...worked. That's not how calling `make` usually goes for me. But I guess we all get lucky sometimes.