### PR TITLE
Fix Ultimate C-Stick angles

### DIFF
--- a/src/dac_algorithms/ultimate_F1.cpp
+++ b/src/dac_algorithms/ultimate_F1.cpp
@@ -122,7 +122,7 @@ GCReport getGCReport(GpioToButtonSets::F1::ButtonSet buttonSet) {
     Coords cxy;
     if (bs.mx && bs.my) cxy = coords(0.0, 0.0);
     else if (cVertical && cHorizontal) cxy = coords(0.7, 0.7);
-    else if (cHorizontal) cxy = bs.mx ? coords(0.8375, readUp ? 0.3125 : -0.3125) : coords(1.0, 0.0);
+    else if (cHorizontal) cxy = bs.mx ? coords(0.7, readUp ? 0.7 : -0.7) : coords(1.0, 0.0);
     else if (cVertical) cxy = coords(0.0, 1.0);
     else cxy = coords(0.0, 0.0);
 


### PR DESCRIPTION
Mx + CL/CR is supposed to produce an fsmash/ftilt/fair angled down, while Mx + Up + CL/CR is supposed to produce angled up.

In Ultimate, the coordinates required to do this are different than they are in Melee, so I have fixed them in Ult mode.
This is also somewhat functionally distinct from just pressing CU/CD+CL/CR; I _believe_ that's a frame perfect input, because Ult will read the angle of cstick on first frame for tilts/aerials.
This has the additional effect of letting you access cstick nair in Smash 4 using Ult mode.