### PR TITLE
Add Ultimate Neutral SOCD Optional Binary

### DIFF
--- a/.github/workflows/cmake-firmware.yml
+++ b/.github/workflows/cmake-firmware.yml
@@ -77,3 +77,15 @@ jobs:
         name: pico_rectangle_${{ github.sha }}.uf2
         path: ${{github.workspace}}/build/pico_rectangle.uf2
         if-no-files-found: error
+    - name: Upload firmware (Ult with 2IP No Reactivation SOCD) artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: pico_rectangle_ult_2ip_no_reac_socd_${{ github.sha }}.uf2
+        path: ${{github.workspace}}/build/pico_rectangle_ULT_2IP_WITH_REAC.uf2
+        if-no-files-found: error
+    - name: Upload firmware (Ult with Neutral SOCD) artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: pico_rectangle_ult_neutral_socd_${{ github.sha }}.uf2
+        path: ${{github.workspace}}/build/pico_rectangle_ULT_NEUTRAL.uf2
+        if-no-files-found: error

--- a/.github/workflows/cmake-firmware.yml
+++ b/.github/workflows/cmake-firmware.yml
@@ -77,10 +77,10 @@ jobs:
         name: pico_rectangle_${{ github.sha }}.uf2
         path: ${{github.workspace}}/build/pico_rectangle.uf2
         if-no-files-found: error
-    - name: Upload firmware (Ult with 2IP No Reactivation SOCD) artifact
+    - name: Upload firmware (Ult with 2IP With Reactivation SOCD) artifact
       uses: actions/upload-artifact@v3
       with:
-        name: pico_rectangle_ult_2ip_no_reac_socd_${{ github.sha }}.uf2
+        name: pico_rectangle_ult_2ip_with_reac_socd_${{ github.sha }}.uf2
         path: ${{github.workspace}}/build/pico_rectangle_ULT_2IP_WITH_REAC.uf2
         if-no-files-found: error
     - name: Upload firmware (Ult with Neutral SOCD) artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
 
-#set(PICO_SDK_PATH "../../pico-sdk")
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 set(PICO_SDK_FETCH_FROM_GIT 1)
 
@@ -9,65 +7,57 @@ include(pico_sdk_import.cmake)
 
 pico_sdk_init()
 
-
 project(pico_rectangle CXX C)
 include_directories(include pico-joybus-comms/include)
-add_executable(
-  pico_rectangle
-  src/main.cpp
-  src/communication_protocols/joybus.cpp
-  src/communication_protocols/usb.cpp
-  src/usb_configurations/gcc_to_usb_adapter.cpp
-  src/usb_configurations/hid_with_triggers.cpp
-  src/usb_configurations/keyboard_8kro.cpp
-  src/usb_configurations/wired_fight_pad_pro.cpp
-  src/usb_configurations/xbox_360.cpp
-  src/dac_algorithms/melee_F1.cpp
-  src/dac_algorithms/project_plus_F1.cpp
-  src/dac_algorithms/ultimate_F1.cpp
-  src/dac_algorithms/set_of_8_keys.cpp
-  src/dac_algorithms/wired_fight_pad_pro_default.cpp
-  src/dac_algorithms/xbox_360.cpp
-  src/gpio_to_button_sets/F1.cpp
-  src/other/runtime_remapping_mode.cpp
-)
-target_compile_definitions(pico_rectangle PRIVATE ULT_2IP_WITH_REAC=0)
-pico_generate_pio_header(pico_rectangle ${CMAKE_CURRENT_LIST_DIR}/pio/my_pio.pio)
-add_custom_command(OUTPUT ${CMAKE_CURRENT_LIST_DIR}/generated/my_pio.pio.h
-        DEPENDS ${CMAKE_CURRENT_LIST_DIR}/my_pio.pio
-        COMMAND Pioasm ${CMAKE_CURRENT_LIST_DIR}/my_pio.pio ${CMAKE_CURRENT_LIST_DIR}/generated/my_pio.pio.h
-        )
-target_link_libraries(pico_rectangle pico_stdlib hardware_pio pico_time pico_bootrom hardware_resets hardware_timer hardware_irq hardware_sync hardware_flash)
-pico_add_extra_outputs(pico_rectangle)
 
+# Define the options as a list
+set(ULT_OPTIONS "ULT_2IP_NO_REAC" "ULT_2IP_WITH_REAC" "ULT_NEUTRAL")
 
-project(pico_rectangle_ult_2ip_with_reac CXX C)
-include_directories(include pico-joybus-comms/include)
-add_executable(
-  pico_rectangle_ult_2ip_with_reac
-  src/main.cpp
-  src/communication_protocols/joybus.cpp
-  src/communication_protocols/usb.cpp
-  src/usb_configurations/gcc_to_usb_adapter.cpp
-  src/usb_configurations/hid_with_triggers.cpp
-  src/usb_configurations/keyboard_8kro.cpp
-  src/usb_configurations/wired_fight_pad_pro.cpp
-  src/usb_configurations/xbox_360.cpp
-  src/dac_algorithms/melee_F1.cpp
-  src/dac_algorithms/project_plus_F1.cpp
-  src/dac_algorithms/ultimate_F1.cpp
-  src/dac_algorithms/set_of_8_keys.cpp
-  src/dac_algorithms/wired_fight_pad_pro_default.cpp
-  src/dac_algorithms/xbox_360.cpp
-  src/gpio_to_button_sets/F1.cpp
-  src/other/runtime_remapping_mode.cpp
-)
-target_compile_definitions(pico_rectangle_ult_2ip_with_reac PRIVATE ULT_2IP_WITH_REAC=1)
-pico_generate_pio_header(pico_rectangle_ult_2ip_with_reac ${CMAKE_CURRENT_LIST_DIR}/pio/my_pio.pio)
-add_custom_command(OUTPUT ${CMAKE_CURRENT_LIST_DIR}/generated/my_pio.pio.h
-        DEPENDS ${CMAKE_CURRENT_LIST_DIR}/my_pio.pio
-        COMMAND Pioasm ${CMAKE_CURRENT_LIST_DIR}/my_pio.pio ${CMAKE_CURRENT_LIST_DIR}/generated/my_pio.pio.h
-        )
-target_link_libraries(pico_rectangle_ult_2ip_with_reac pico_stdlib hardware_pio pico_time pico_bootrom hardware_resets hardware_timer hardware_irq hardware_sync hardware_flash)
-pico_add_extra_outputs(pico_rectangle_ult_2ip_with_reac)
-
+# Loop through the options and create a target for each one
+foreach(ULT_OPTION ${ULT_OPTIONS})
+  # Create a target name for the current option
+  set(TARGET_NAME "pico_rectangle_${ULT_OPTION}")
+  # If this is the default option, set the output file name to "pico_rectangle"
+  if(${ULT_OPTION} STREQUAL "ULT_2IP_NO_REAC")
+    set(TARGET_NAME "pico_rectangle")
+  endif()
+  
+  # Add an executable target for the current option
+  add_executable(${TARGET_NAME}
+    src/main.cpp
+    src/communication_protocols/joybus.cpp
+    src/communication_protocols/usb.cpp
+    src/usb_configurations/gcc_to_usb_adapter.cpp
+    src/usb_configurations/hid_with_triggers.cpp
+    src/usb_configurations/keyboard_8kro.cpp
+    src/usb_configurations/wired_fight_pad_pro.cpp
+    src/usb_configurations/xbox_360.cpp
+    src/dac_algorithms/melee_F1.cpp
+    src/dac_algorithms/project_plus_F1.cpp
+    src/dac_algorithms/ultimate_F1.cpp
+    src/dac_algorithms/set_of_8_keys.cpp
+    src/dac_algorithms/wired_fight_pad_pro_default.cpp
+    src/dac_algorithms/xbox_360.cpp
+    src/gpio_to_button_sets/F1.cpp
+    src/other/runtime_remapping_mode.cpp
+  )
+  
+  # Add compile definitions for the current option
+  target_compile_definitions(${TARGET_NAME} PRIVATE ${ULT_OPTION}=1)
+  
+  # Generate the PIO header
+  pico_generate_pio_header(${TARGET_NAME} ${CMAKE_CURRENT_LIST_DIR}/pio/my_pio.pio)
+  
+  # Add the custom command for generating the PIO header
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_LIST_DIR}/generated/my_pio.pio.h
+          DEPENDS ${CMAKE_CURRENT_LIST_DIR}/my_pio.pio
+          COMMAND Pioasm ${CMAKE_CURRENT_LIST_DIR}/my_pio.pio ${CMAKE_CURRENT_LIST_DIR}/generated/my_pio.pio.h
+  )
+  
+  # Link libraries for the current option
+  target_link_libraries(${TARGET_NAME} pico_stdlib hardware_pio pico_time pico_bootrom hardware_resets hardware_timer hardware_irq hardware_sync hardware_flash)
+  
+  # Add extra outputs for the current option
+  pico_add_extra_outputs(${TARGET_NAME})
+  
+endforeach()

--- a/src/dac_algorithms/ultimate_F1.cpp
+++ b/src/dac_algorithms/ultimate_F1.cpp
@@ -41,23 +41,6 @@ GCReport getGCReport(GpioToButtonSets::F1::ButtonSet buttonSet) {
     GpioToButtonSets::F1::ButtonSet bs = buttonSet; // Alterable copy
 
     GCReport gcReport = defaultGcReport;
-    
-    // Enforce neutral SOCD to test
-    if (bs.left && bs.right) {
-
-        bs.left = false;
-
-        bs.right = false;
-
-    }
-
-    if (bs.down && bs.up) {
-
-        bs.down = false;
-
-        bs.up = false;
-
-    }
 
 #if ULT_2IP_WITH_REAC
     /* 2IP with reactivation */
@@ -79,6 +62,17 @@ GCReport getGCReport(GpioToButtonSets::F1::ButtonSet buttonSet) {
     if (bs.down && bs.up) {
         if (up_isTheMostRecentPressed) bs.down = false;
         else bs.up = false;
+    }
+#elif ULT_NEUTRAL
+    /* Neutral SOCD */
+    if (bs.left && bs.right) {
+        bs.left = false;
+        bs.right = false;
+    }
+
+    if (bs.down && bs.up) {
+        bs.down = false;
+        bs.up = false;
     }
 #else
     /* 2IP no reactivation */

--- a/src/dac_algorithms/ultimate_F1.cpp
+++ b/src/dac_algorithms/ultimate_F1.cpp
@@ -41,6 +41,23 @@ GCReport getGCReport(GpioToButtonSets::F1::ButtonSet buttonSet) {
     GpioToButtonSets::F1::ButtonSet bs = buttonSet; // Alterable copy
 
     GCReport gcReport = defaultGcReport;
+    
+    // Enforce neutral SOCD to test
+    if (bs.left && bs.right) {
+
+        bs.left = false;
+
+        bs.right = false;
+
+    }
+
+    if (bs.down && bs.up) {
+
+        bs.down = false;
+
+        bs.up = false;
+
+    }
 
 #if ULT_2IP_WITH_REAC
     /* 2IP with reactivation */


### PR DESCRIPTION
Neutral SOCD is legal in Smash Ultimate: https://smashworldtour.com/wp-content/uploads/2021/02/SWT-2021-Rulebook-2020.2.16.pdf

> If two opposing cardinal directions are activated simultaneously, the
> following controller-side SOCD resolution methods are permitted:
> - A neutral input (neither cardinal direction) is produced
> - The more recent cardinal direction overrides the less recent
> cardinal direction and the less recent cardinal direction is
> deactivated until manually activated again.
>
> If two opposing cardinal directions are first activated simultaneously, the
> controller may either produce a neutral input or may give priority to one of
> the cardinal directions in a predetermined manner

- [x] Converted CMake file to have a loop with environment variables for ease of onboarding new ones such as Ult Neutral SOCD. I think https://github.com/JulienBernard3383279/pico-rectangle/pull/26 could also use this to add `MELEE_NEUTRAL` easily.
- [x] Added Neutral SOCD for Ultimate based on `ULT_NEUTRAL` environment variable
- [x] Update Github Action to upload all three artifacts with appropriate naming 